### PR TITLE
Supply XML types, manual Hashable instances

### DIFF
--- a/library/OpcXmlDaClient/Prelude.hs
+++ b/library/OpcXmlDaClient/Prelude.hs
@@ -1,24 +1,39 @@
 module OpcXmlDaClient.Prelude
-( 
-  module Exports,
-)
+  ( module Exports,
+  )
 where
 
 -- base
 -------------------------
-import Control.Applicative as Exports hiding (WrappedArrow(..))
+import Control.Applicative as Exports hiding (WrappedArrow (..))
 import Control.Arrow as Exports hiding (first, second)
 import Control.Category as Exports
 import Control.Concurrent as Exports
 import Control.Exception as Exports
-import Control.Monad as Exports hiding (fail, mapM_, sequence_, forM_, msum, mapM, sequence, forM)
-import Control.Monad.IO.Class as Exports
+import Control.Monad as Exports hiding (fail, forM, forM_, mapM, mapM_, msum, sequence, sequence_)
 import Control.Monad.Fail as Exports
 import Control.Monad.Fix as Exports hiding (fix)
+-- bytestring
+-------------------------
+
+-- text
+-------------------------
+
+-- transformers
+-------------------------
+import Control.Monad.IO.Class as Exports
 import Control.Monad.ST as Exports
+import Control.Monad.Trans.Class as Exports
+import Control.Monad.Trans.Cont as Exports hiding (callCC, shift)
+import Control.Monad.Trans.Except as Exports (Except, ExceptT (ExceptT), catchE, except, mapExcept, mapExceptT, runExcept, runExceptT, throwE, withExcept, withExceptT)
+import Control.Monad.Trans.Maybe as Exports
+import Control.Monad.Trans.Reader as Exports (Reader, ReaderT (ReaderT), ask, mapReader, mapReaderT, runReader, runReaderT, withReader, withReaderT)
+import Control.Monad.Trans.State.Strict as Exports (State, StateT (StateT), evalState, evalStateT, execState, execStateT, mapState, mapStateT, runState, runStateT, withState, withStateT)
+import Control.Monad.Trans.Writer.Strict as Exports (Writer, WriterT (..), execWriter, execWriterT, mapWriter, mapWriterT, runWriter)
 import Data.Bifunctor as Exports
 import Data.Bits as Exports
 import Data.Bool as Exports
+import Data.ByteString as Exports (ByteString)
 import Data.Char as Exports
 import Data.Coerce as Exports
 import Data.Complex as Exports
@@ -30,22 +45,40 @@ import Data.Foldable as Exports hiding (toList)
 import Data.Function as Exports hiding (id, (.))
 import Data.Functor as Exports
 import Data.Functor.Compose as Exports
-import Data.Int as Exports
+import Data.Functor.Identity as Exports
+-- hashable-time
+-------------------------
+import Data.Hashable.Time ()
 import Data.IORef as Exports
+import Data.Int as Exports
 import Data.Ix as Exports
-import Data.List as Exports hiding (sortOn, isSubsequenceOf, uncons, concat, foldr, foldl1, maximum, minimum, product, sum, all, and, any, concatMap, elem, foldl, foldr1, notElem, or, find, maximumBy, minimumBy, mapAccumL, mapAccumR, foldl')
-import Data.List.NonEmpty as Exports (NonEmpty(..))
+import Data.List as Exports hiding (all, and, any, concat, concatMap, elem, find, foldl, foldl', foldl1, foldr, foldr1, isSubsequenceOf, mapAccumL, mapAccumR, maximum, maximumBy, minimum, minimumBy, notElem, or, product, sortOn, sum, uncons)
+import Data.List.NonEmpty as Exports (NonEmpty (..))
 import Data.Maybe as Exports
 import Data.Monoid as Exports hiding (Alt)
 import Data.Ord as Exports
 import Data.Proxy as Exports
 import Data.Ratio as Exports
-import Data.Semigroup as Exports hiding (First(..), Last(..))
 import Data.STRef as Exports
+-- vector-instances
+-------------------------
+
+-- scientific
+-------------------------
+import Data.Scientific as Exports (Scientific)
+import Data.Semigroup as Exports hiding (First (..), Last (..))
 import Data.String as Exports
+import Data.Text as Exports (Text)
+-- time
+-------------------------
+import Data.Time as Exports (LocalTime, TimeZone)
 import Data.Traversable as Exports
 import Data.Tuple as Exports
 import Data.Unique as Exports
+-- vector
+-------------------------
+import Data.Vector as Exports (Vector)
+import Data.Vector.Instances ()
 import Data.Version as Exports
 import Data.Void as Exports
 import Data.Word as Exports
@@ -54,13 +87,12 @@ import Foreign.ForeignPtr as Exports
 import Foreign.Ptr as Exports
 import Foreign.StablePtr as Exports
 import Foreign.Storable as Exports
-import GHC.Conc as Exports hiding (orElse, withMVar, threadWaitWriteSTM, threadWaitWrite, threadWaitReadSTM, threadWaitRead)
-import GHC.Exts as Exports (IsList(..), lazy, inline, sortWith, groupWith)
+import GHC.Conc as Exports hiding (orElse, threadWaitRead, threadWaitReadSTM, threadWaitWrite, threadWaitWriteSTM, withMVar)
+import GHC.Exts as Exports (IsList (..), groupWith, inline, lazy, sortWith)
 import GHC.Generics as Exports (Generic)
 import GHC.IO.Exception as Exports
 import GHC.OverloadedLabels as Exports
 import Numeric as Exports
-import Prelude as Exports hiding (fail, concat, foldr, mapM_, sequence_, foldl1, maximum, minimum, product, sum, all, and, any, concatMap, elem, foldl, foldr1, notElem, or, mapM, sequence, id, (.))
 import System.Environment as Exports
 import System.Exit as Exports
 import System.IO as Exports (Handle, hClose)
@@ -70,48 +102,8 @@ import System.Mem as Exports
 import System.Mem.StableName as Exports
 import System.Timeout as Exports
 import Text.ParserCombinators.ReadP as Exports (ReadP, readP_to_S, readS_to_P)
-import Text.ParserCombinators.ReadPrec as Exports (ReadPrec, readPrec_to_P, readP_to_Prec, readPrec_to_S, readS_to_Prec)
-import Text.Printf as Exports (printf, hPrintf)
-import Text.Read as Exports (Read(..), readMaybe, readEither)
+import Text.ParserCombinators.ReadPrec as Exports (ReadPrec, readP_to_Prec, readPrec_to_P, readPrec_to_S, readS_to_Prec)
+import Text.Printf as Exports (hPrintf, printf)
+import Text.Read as Exports (Read (..), readEither, readMaybe)
 import Unsafe.Coerce as Exports
-
--- bytestring
--------------------------
-import Data.ByteString as Exports (ByteString)
-
--- text
--------------------------
-import Data.Text as Exports (Text)
-
--- transformers
--------------------------
-import Control.Monad.IO.Class as Exports
-import Control.Monad.Trans.Class as Exports
-import Control.Monad.Trans.Cont as Exports hiding (shift, callCC)
-import Control.Monad.Trans.Except as Exports (ExceptT(ExceptT), Except, except, runExcept, runExceptT, mapExcept, mapExceptT, withExcept, withExceptT, throwE, catchE)
-import Control.Monad.Trans.Maybe as Exports
-import Control.Monad.Trans.Reader as Exports (Reader, ask, runReader, mapReader, withReader, ReaderT(ReaderT), runReaderT, mapReaderT, withReaderT)
-import Control.Monad.Trans.State.Strict as Exports (State, runState, evalState, execState, mapState, withState, StateT(StateT), runStateT, evalStateT, execStateT, mapStateT, withStateT)
-import Control.Monad.Trans.Writer.Strict as Exports (Writer, runWriter, execWriter, mapWriter, WriterT(..), execWriterT, mapWriterT)
-import Data.Functor.Compose as Exports
-import Data.Functor.Identity as Exports
-
--- hashable-time
--------------------------
-import Data.Hashable.Time ()
-
--- vector-instances
--------------------------
-import Data.Vector.Instances ()
-
--- scientific
--------------------------
-import Data.Scientific (Scientific)
-
--- time
--------------------------
-import Data.Time (LocalTime, TimeZone)
-
--- vector
--------------------------
-import Data.Vector (Vector)
+import Prelude as Exports hiding (all, and, any, concat, concatMap, elem, fail, foldl, foldl1, foldr, foldr1, id, mapM, mapM_, maximum, minimum, notElem, or, product, sequence, sequence_, sum, (.))

--- a/library/OpcXmlDaClient/Protocol.hs
+++ b/library/OpcXmlDaClient/Protocol.hs
@@ -28,6 +28,7 @@ import Domain
     typeableDeriver,
   )
 import OpcXmlDaClient.Prelude hiding (Read)
+import OpcXmlDaClient.XmlTypes (XmlDateTime, XmlQName, XmlValue)
 
 declare
   (Just (True, False))

--- a/library/OpcXmlDaClient/XmlTypes.hs
+++ b/library/OpcXmlDaClient/XmlTypes.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE LambdaCase #-}
+
+module OpcXmlDaClient.XmlTypes
+  ( XmlValue (..),
+    XmlQName (..),
+    XmlDateTime (..),
+  )
+where
+
+import Data.Hashable (Hashable (hashWithSalt))
+import Data.Hashable.Generic (genericHashWithSalt)
+import Data.Hashable.Lifted (liftHashWithSalt)
+import Data.XML.Types
+  ( Content,
+    Element (Element),
+    Name,
+    Node (NodeComment, NodeContent, NodeElement, NodeInstruction),
+  )
+import OpcXmlDaClient.Prelude
+
+-- | An XML Schema @dateTime@.
+--
+-- /Reference:/ [XML Schema 2
+-- @dateTime@](https://www.w3.org/TR/xmlschema-2/#dateTime)
+--
+-- @since 0.1
+data XmlDateTime = XmlDateTime !LocalTime !(Maybe TimeZone)
+  deriving stock
+    ( -- | @since 0.1
+      Show,
+      -- | This is /not/ standard-conformant, as the equality relation is
+      -- partial for @dateTime@.
+      --
+      -- @since 0.1
+      Eq,
+      -- | This is /not/ standard-conformant, as the ordering relation is
+      -- partial for @dateTime@.
+      --
+      -- @since 0.1
+      Ord,
+      -- | @since 0.1
+      Data
+    )
+
+-- | @since 0.1
+instance Hashable XmlDateTime where
+  {-# INLINEABLE hashWithSalt #-}
+  hashWithSalt salt (XmlDateTime lt mtz) = salt `hashWithSalt` lt `hashWithSalt` mtz
+
+-- | An XML qualified name.
+--
+-- /References:/
+--    * [Wikipedia overview](https://en.wikipedia.org/wiki/QName)
+--    * [Standard text](https://www.w3.org/TR/REC-xml-names/#NT-QName)
+--
+-- @since 0.1
+newtype XmlQName = XmlQName Name
+  deriving stock
+    ( -- | @since 0.1
+      Show,
+      -- | @since 0.1
+      Data
+    )
+  deriving
+    ( -- | @since 0.1
+      Eq,
+      -- | @since 0.1
+      Ord
+    )
+    via Name
+
+-- | @since 0.1
+instance Hashable XmlQName where
+  {-# INLINEABLE hashWithSalt #-}
+  hashWithSalt salt (XmlQName n) = genericHashWithSalt salt n
+
+-- | An XML fragment that does not necessarily constitute a full document.
+--
+-- @since 0.1
+newtype XmlValue = XmlValue Element
+  deriving stock
+    ( -- | @since 0.1
+      Show,
+      -- | @since 0.1
+      Data
+    )
+  deriving
+    ( -- | @since 0.1
+      Eq,
+      -- | @since 0.1
+      Ord
+    )
+    via Element
+
+-- | @since 0.1
+instance Hashable XmlValue where
+  {-# INLINEABLE hashWithSalt #-}
+  hashWithSalt salt (XmlValue el) = hashElement salt el
+    where
+      hashElement :: Int -> Element -> Int
+      hashElement salt' (Element n as ns) =
+        let s1 = genericHashWithSalt salt' n
+            s2 = liftHashWithSalt hashContents s2 as
+         in liftHashWithSalt hashNode s2 ns
+      hashContents :: Int -> (Name, [Content]) -> Int
+      hashContents salt' (n, cs) =
+        let s1 = genericHashWithSalt salt' n
+         in liftHashWithSalt genericHashWithSalt s1 cs
+      hashNode :: Int -> Node -> Int
+      hashNode salt' = \case
+        NodeElement elt -> salt' `hashElement` elt `hashWithSalt` (0 :: Int)
+        NodeInstruction inst -> salt' `genericHashWithSalt` inst `hashWithSalt` (1 :: Int)
+        NodeContent cont -> salt' `genericHashWithSalt` cont `hashWithSalt` (2 :: Int)
+        NodeComment comm -> salt `hashWithSalt` comm `hashWithSalt` (3 :: Int)

--- a/opc-xml-da-client.cabal
+++ b/opc-xml-da-client.cabal
@@ -18,15 +18,18 @@ library
   other-modules:
     OpcXmlDaClient.Prelude
     OpcXmlDaClient.Protocol
+    OpcXmlDaClient.XmlTypes
 
   build-depends:
-    , base              >=4.14     && <5
-    , bytestring        >=0.10     && <0.12
+    , base              >=4.14    && <5
+    , bytestring        >=0.10    && <0.12
     , domain            ^>=0.1.1
-    , hashable-time     >=0.2      && <0.4
+    , hashable          ^>=1.3.2.0
+    , hashable-time     >=0.2     && <0.4
     , scientific        ^>=0.3.6.2
-    , text              >=1        && <2
-    , time              >=1.9.3    && <1.12
+    , text              >=1       && <2
+    , time              >=1.9.3   && <1.12
     , transformers      ^>=0.5
     , vector            ^>=0.12
     , vector-instances  ^>=3.4
+    , xml-types         ^>=0.3.8

--- a/schemas/protocol.yaml
+++ b/schemas/protocol.yaml
@@ -1,23 +1,3 @@
-# XML base types
-
-# Reference: https://www.w3schools.com/xml/schema_dtypes_date.asp
-#
-# TODO: It might be better to borrow this from an XML library.
-XmlDateTime:
-  product:
-    zone: Maybe TimeZone
-    dateTime: LocalTime
-
-# Reference: https://en.wikipedia.org/wiki/QName
-#
-# TODO: Either implement this or borrow from another library.
-XmlQName:
-  product:
-
-# TODO: Either implement this or borrow from another library.
-XmlValue:
-  product:
-
 # XML-DA base types
 
 GetStatus:


### PR DESCRIPTION
I've left the wrappers intact name-wise, because I believe them to be clearer. This also avoids orphans by deriving everything via the `Generic` instances in `xml-types`, but this is _very_ slow-compiling. We could either hand-roll all the hashing without `Generic` (tedious, error-prone and slow) or we can send a PR to `xml-types`.