### PR TITLE
Inline xml types, ditching the Hashable derivation

### DIFF
--- a/library/OpcXmlDaClient/Protocol.hs
+++ b/library/OpcXmlDaClient/Protocol.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -26,7 +25,6 @@ Domain.declare
         Domain.genericDeriver,
         Domain.dataDeriver,
         Domain.typeableDeriver,
-        Domain.hashableDeriver,
         Domain.hasFieldDeriver,
         Domain.constructorIsLabelDeriver,
         Domain.accessorIsLabelDeriver,
@@ -34,69 +32,3 @@ Domain.declare
       ]
   )
   =<< Domain.loadSchema "schemas/protocol.yaml"
-
--- | An XML qualified name.
---
--- /References:/
---    * [Wikipedia overview](https://en.wikipedia.org/wiki/QName)
---    * [Standard text](https://www.w3.org/TR/REC-xml-names/#NT-QName)
---
--- @since 0.1
-newtype XmlQName = XmlQName Xml.Name
-  deriving stock
-    ( -- | @since 0.1
-      Show,
-      -- | @since 0.1
-      Data
-    )
-  deriving
-    ( -- | @since 0.1
-      Eq,
-      -- | @since 0.1
-      Ord
-    )
-    via Xml.Name
-
--- | @since 0.1
-instance Hashable XmlQName where
-  {-# INLINEABLE hashWithSalt #-}
-  hashWithSalt salt (XmlQName n) = genericHashWithSalt salt n
-
--- | An XML fragment that does not necessarily constitute a full document.
---
--- @since 0.1
-newtype XmlElement = XmlElement Xml.Element
-  deriving stock
-    ( -- | @since 0.1
-      Show,
-      -- | @since 0.1
-      Data
-    )
-  deriving
-    ( -- | @since 0.1
-      Eq,
-      -- | @since 0.1
-      Ord
-    )
-    via Xml.Element
-
--- | @since 0.1
-instance Hashable XmlElement where
-  {-# INLINEABLE hashWithSalt #-}
-  hashWithSalt salt (XmlElement el) = hashElement salt el
-    where
-      hashElement :: Int -> Xml.Element -> Int
-      hashElement salt' (Xml.Element n as ns) =
-        let s1 = genericHashWithSalt salt' n
-            s2 = liftHashWithSalt hashContents s2 as
-         in liftHashWithSalt hashNode s2 ns
-      hashContents :: Int -> (Xml.Name, [Xml.Content]) -> Int
-      hashContents salt' (n, cs) =
-        let s1 = genericHashWithSalt salt' n
-         in liftHashWithSalt genericHashWithSalt s1 cs
-      hashNode :: Int -> Xml.Node -> Int
-      hashNode salt' = \case
-        Xml.NodeElement elt -> salt' `hashElement` elt `hashWithSalt` (0 :: Int)
-        Xml.NodeInstruction inst -> salt' `genericHashWithSalt` inst `hashWithSalt` (1 :: Int)
-        Xml.NodeContent cont -> salt' `genericHashWithSalt` cont `hashWithSalt` (2 :: Int)
-        Xml.NodeComment comm -> salt `hashWithSalt` comm `hashWithSalt` (3 :: Int)

--- a/schemas/protocol.yaml
+++ b/schemas/protocol.yaml
@@ -61,13 +61,13 @@ ReadRequestItemList:
   product:
     items: Vector ReadRequestItem
     itemPath: Maybe Text
-    reqType: Maybe XmlQName
+    reqType: Maybe Xml.Name
     maxAge: Maybe Int32
 
 ReadRequestItem:
   product:
     itemPath: Maybe Text
-    reqType: Maybe XmlQName
+    reqType: Maybe Xml.Name
     itemName: Maybe Text
     clientItemHandle: Maybe Text
     maxAge: Maybe Int32
@@ -86,14 +86,14 @@ ReplyItemList:
 ItemValue:
   product:
     diagnosticInfo: Maybe Text
-    value: Maybe XmlElement
+    value: Maybe Xml.Element
     quality: Maybe OpcQuality
-    valueTypeQualifier: Maybe XmlQName
+    valueTypeQualifier: Maybe Xml.Name
     itemPath: Maybe Text
     itemName: Maybe Text
     clientItemHandle: Maybe Text
     timestamp: Maybe DateTime
-    resultId: Maybe XmlQName
+    resultId: Maybe Xml.Name
 
 OpcQuality:
   product:
@@ -130,7 +130,7 @@ LimitBits:
 OpcError:
   product:
     text: Maybe Text
-    id: XmlQName
+    id: Xml.Name
 
 # TODO: This would be better just as unboxed Vector Float.
 ArrayOfFloat:
@@ -182,10 +182,10 @@ ArrayOfDateTime:
   product:
     dateTime: Vector DateTime
 
-# TODO: This would be better just as Vector (Maybe XmlElement).
+# TODO: This would be better just as Vector (Maybe Xml.Element).
 ArrayOfAnyType:
   product:
-    anyType: Vector (Maybe XmlElement)
+    anyType: Vector (Maybe Xml.Element)
 
 # TODO: This would be better as Vector Scientific.
 ArrayOfDecimal:
@@ -230,7 +230,7 @@ SubscribeRequestItemList:
   product:
     items: Vector SubscribeRequestItem
     itemPath: Maybe Text
-    reqType: Maybe XmlQName
+    reqType: Maybe Xml.Name
     deadband: Maybe Float
     requestedSamplingRate: Maybe Int32
     enableBuffering: Maybe Bool
@@ -238,7 +238,7 @@ SubscribeRequestItemList:
 SubscribeRequestItem:
   product:
     itemPath: Maybe Text
-    reqType: Maybe XmlQName
+    reqType: Maybe Xml.Name
     itemName: Maybe Text
     clientItemHandle: Maybe Text
     deadband: Maybe Float
@@ -294,7 +294,7 @@ SubscriptionCancelResponse:
 
 Browse:
   product:
-    propertyNames: Vector XmlQName
+    propertyNames: Vector Xml.Name
     localeId: Maybe Text
     clientRequestHandle: Maybe Text
     itemPath: Maybe Text
@@ -325,12 +325,12 @@ BrowseElement:
 
 ItemProperty:
   product:
-    value: Maybe XmlElement
-    name: XmlQName
+    value: Maybe Xml.Element
+    name: Xml.Name
     description: Maybe Text
     itemPath: Maybe Text
     itemName: Maybe Text
-    resultId: Maybe XmlQName
+    resultId: Maybe Xml.Name
 
 BrowseResponse:
   product:
@@ -343,7 +343,7 @@ BrowseResponse:
 GetProperties:
   product:
     itemIds: Vector ItemIdentifier
-    propertyNames: Vector XmlQName
+    propertyNames: Vector Xml.Name
     localeId: Maybe Text
     clientRequestHandle: Maybe Text
     itemPath: Maybe Text
@@ -361,7 +361,7 @@ PropertyReplyList:
     properties: Vector ItemProperty
     itemPath: Maybe Text
     itemName: Maybe Text
-    resultId: Maybe XmlQName
+    resultId: Maybe Xml.Name
 
 GetPropertiesResponse:
   product:


### PR DESCRIPTION
It seems like we don't need the Hashable instances and that it was the only reason to have the wrapper types. Getting rid of them should simplify things a bit. What do you think?