### PR TITLE
Implement parsing of custom fault codes

### DIFF
--- a/protocol-test/Main.hs
+++ b/protocol-test/Main.hs
@@ -51,7 +51,7 @@ main =
            in [ testCase "" $ do
                   assertEqual
                     ""
-                    (Right (Left (SoapFault SenderSoapFaultCode "Server was unable to read request. ---> There is an error in XML document (4, 32). ---> The string 'dateTime' is not a valid AllXsd value.")))
+                    (Right (Left (SoapFault (#std SenderStdSoapFaultCode) "Server was unable to read request. ---> There is an error in XML document (4, 32). ---> The string 'dateTime' is not a valid AllXsd value.")))
                     parsingResult
               ],
         testGroup "Fault on old SOAP Response" $
@@ -61,7 +61,7 @@ main =
            in [ testCase "" $ do
                   assertEqual
                     ""
-                    (Right (Left (SoapFault SenderSoapFaultCode "XML syntax error")))
+                    (Right (Left (SoapFault (#std SenderStdSoapFaultCode) "XML syntax error")))
                     parsingResult
               ]
       ]

--- a/protocol/OpcXmlDaClient/Protocol/Namespaces.hs
+++ b/protocol/OpcXmlDaClient/Protocol/Namespaces.hs
@@ -2,12 +2,13 @@ module OpcXmlDaClient.Protocol.Namespaces where
 
 import OpcXmlDaClient.Base.Prelude
 
+-- |
+-- Namespace for SOAP v1.2.
 soapEnv :: Text =
   "http://www.w3.org/2003/05/soap-envelope"
 
 -- |
--- It appears that the W3C-standardized namespace for SOAP envelope
--- is not the only one used in reality :(.
+-- Namespace for SOAP v <1.2
 soapEnv2 :: Text =
   "http://schemas.xmlsoap.org/soap/envelope/"
 

--- a/protocol/types.domain.yaml
+++ b/protocol/types.domain.yaml
@@ -422,8 +422,13 @@ SoapFault:
     code: SoapFaultCode
     reason: Text
 
-# https://www.w3.org/TR/soap12-part1/#faultcodes
 SoapFaultCode:
+  sum:
+    std: StdSoapFaultCode
+    custom: QName
+
+# https://www.w3.org/TR/soap12-part1/#faultcodes
+StdSoapFaultCode:
   enum:
     # The faulting node found an invalid element information item instead of the expected Envelope element information item. The namespace, local name or both did not match the Envelope element information item required by this recommendation (see 2.8 SOAP Versioning Model and 5.4.7 VersionMismatch Faults)
     - versionMismatch


### PR DESCRIPTION
This is to fix the issue of the following error:

```
Just ("<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:SOAP-ENC=\"http://schemas.xmlsoap.org
/soap/encoding/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:ns1=\"http://opcfou
ndation.org/webservices/XMLDA/1.0/\" xmlns:ns2=\"Service\"><SOAP-ENV:Header></SOAP-ENV:Header><SOAP-ENV:Body id=\"_0\"><SOAP-ENV:Fault><faultcode>
E_NOSUBSCRIPTION</faultcode><faultstring>E_NOSUBSCRIPTION</faultstring><detail>E_NOSUBSCRIPTION</detail></SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-EN
V:Envelope>",[Parsing error: /Body/Fault/faultcode/0: Not a SOAP ENV ns: Nothing,Parsing error: /Body/Fault/faultcode/0: Not a SOAP ENV ns: Nothin
g,Parsing error: /Body/Fault/faultcode/0: Not a SOAP ENV ns: Nothing,Parsing error: /Body/Fault/faultcode/0: Not a SOAP ENV ns: Nothing,Parsing er
ror: /Body/Fault/faultcode/0: Not a SOAP ENV ns: Nothing,Parsing error: /Body/Fault/faultcode/0: Not a SOAP ENV ns: Nothing,Parsing error: /Body/F
ault/faultcode/0: Not a SOAP ENV ns: Nothing,Parsing error: /Body/Fault/faultcode/0: Not a SOAP ENV ns: Nothing])
```