### PR TITLE
rename a Browse attribute

### DIFF
--- a/protocol/OpcXmlDaClient/Protocol/XmlConstruction.hs
+++ b/protocol/OpcXmlDaClient/Protocol/XmlConstruction.hs
@@ -355,7 +355,7 @@ browseElement elementName x =
           ("ElementNameFilter",) . X.textContent <$> #elementNameFilter x,
           ("VendorFilter",) . X.textContent <$> #vendorFilter x,
           pure ("ReturnAllProperties", booleanContent (#returnAllProperties x)),
-          pure ("ReturnAllPropertyValues", booleanContent (#returnAllPropertyValues x)),
+          pure ("ReturnPropertyValues", booleanContent (#returnAllPropertyValues x)),
           pure ("ReturnErrorText", booleanContent (#returnErrorText x))
         ]
     )


### PR DESCRIPTION
The Browse attribute is called ReturnPropertyValues and not ReturnAllPropertyValues according to the OPC 1.0 WSDL standard.
Perhaps the attribute should also be re-named in the types.domain.yaml document.